### PR TITLE
Extract last_incomplete_order to method.

### DIFF
--- a/core/lib/spree/core/controller_helpers/order.rb
+++ b/core/lib/spree/core/controller_helpers/order.rb
@@ -50,7 +50,6 @@ module Spree
 
         def set_current_order
           if user = try_spree_current_user
-            last_incomplete_order = user.last_incomplete_spree_order
             if cookies.signed[:guest_token].nil? && last_incomplete_order
               cookies.permanent.signed[:guest_token] = last_incomplete_order.guest_token
             elsif current_order && last_incomplete_order && current_order != last_incomplete_order
@@ -68,6 +67,10 @@ module Spree
         end
 
         private
+        def last_incomplete_order
+          @last_incomplete_order ||= try_spree_current_user.last_incomplete_spree_order
+        end
+
         def current_order_params
           { currency: current_currency, guest_token: cookies.signed[:guest_token], user_id: try_spree_current_user.try(:id) }
         end


### PR DESCRIPTION
Extracting this logic to its own method allows store maintainers (i.e.
me!) to override this functionality to retreive orders using the logic
that makes sense for their customized version of the store. As an
example, you can override this to return nil to never do order merging,
or place additional restrictions on what the last incomplete spree order
is for a specific user.
