### PR TITLE
Simple fix for payment source.

### DIFF
--- a/backend/app/controllers/spree/admin/payments_controller.rb
+++ b/backend/app/controllers/spree/admin/payments_controller.rb
@@ -22,7 +22,7 @@ module Spree
       def create
         invoke_callbacks(:create, :before)
         @payment ||= @order.payments.build(object_params)
-        if params[:card].present? and params[:card] != 'new'
+        if @payment.payment_method.source_required? && params[:card].present? and params[:card] != 'new'
           @payment.source = @payment.payment_method.payment_source_class.find_by_id(params[:card])
         end
 


### PR DESCRIPTION
Steps to reproduce the issue:
1. Add an order through the admin interface
2. Attempt to pay via cheque for a user who has a credit card number
   stored in their profile.
3. Submit the form

This will 500, because params[:card] is set from the form on the initial
page for the radio button from the credit card profiles.

This is a simple, though incomplete fix for the issue. A proper fix
would be to change the form so that params[:card] is qualified by the
payment_method which it belongs.

There are also likely issues with multiple payment methods which support
profiles, as there is likely to be confusion between them. This should
suffice for now.
