### PR TITLE
2 3 promotion line item eligible

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,1 +1,8 @@
 ## Spree 2.3.2 (unreleased) ##
+* Added `actionable?` for Spree::Promotion::Rule. `actionable?` defines
+  if a promotion action can be applied to a specific line item. This
+  can be used to customize which line items can accept a promotion
+  action by defining its logic within the promotion rule rather than
+  relying on Spree's default behaviour. Fixes #5036
+
+    Gregor MacDougall

--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -50,6 +50,7 @@ module Spree
     scope :eligible, -> { where(eligible: true) }
     scope :charge, -> { where("#{quoted_table_name}.amount >= 0") }
     scope :credit, -> { where("#{quoted_table_name}.amount < 0") }
+    scope :nonzero, -> { where("#{quoted_table_name}.amount != 0") }
     scope :promotion, -> { where(source_type: 'Spree::PromotionAction') }
     scope :return_authorization, -> { where(source_type: "Spree::ReturnAuthorization") }
     scope :included, -> { where(included: true)  }

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -40,6 +40,7 @@ module Spree
         # Ensure a negative amount which does not exceed the sum of the order's
         # item_total and ship_total
         def compute_amount(adjustable)
+          return 0 unless promotion.line_item_actionable? adjustable.order, adjustable
           promotion_amount = self.calculator.compute(adjustable).to_f.abs
           
           [adjustable.amount, promotion_amount].min * -1

--- a/core/app/models/spree/promotion/actions/create_item_adjustments.rb
+++ b/core/app/models/spree/promotion/actions/create_item_adjustments.rb
@@ -14,12 +14,11 @@ module Spree
 
         def perform(payload = {})
           order = payload[:order]
-          # Find only the line items which have not already been adjusted by this promotion
-          # HACK: Need to use [0] because `pluck` may return an empty array, which AR helpfully
-          # coverts to meaning NOT IN (NULL) and the DB isn't happy about that.
-          already_adjusted_line_items = [0] + self.adjustments.pluck(:adjustable_id)
+          promotion = payload[:promotion]
+
           result = false
-          order.line_items.where("id NOT IN (?)", already_adjusted_line_items).find_each do |line_item|
+
+          line_items_to_adjust(promotion, order).each do |line_item|
             current_result = self.create_adjustment(line_item, order)
             result ||= current_result
           end
@@ -29,7 +28,6 @@ module Spree
         def create_adjustment(adjustable, order)
           amount = self.compute_amount(adjustable)
           return if amount == 0
-          return if promotion.product_ids.present? and !promotion.product_ids.include?(adjustable.product.id)
           self.adjustments.create!(
             amount: amount,
             adjustable: adjustable,
@@ -61,6 +59,13 @@ module Spree
           def ensure_action_has_calculator
             return if self.calculator
             self.calculator = Calculator::PercentOnLineItem.new
+          end
+
+          def line_items_to_adjust(promotion, order)
+            excluded_ids = self.adjustments.pluck(:adjustable_id)
+            order.line_items.where.not(id: excluded_ids).select do |line_item|
+              promotion.line_item_actionable? order, line_item
+            end
           end
 
       end

--- a/core/app/models/spree/promotion/rules/product.rb
+++ b/core/app/models/spree/promotion/rules/product.rb
@@ -30,6 +30,10 @@ module Spree
           end
         end
 
+        def actionable?(line_item)
+          product_ids.include? line_item.variant.product_id
+        end
+
         def product_ids_string
           product_ids.join(',')
         end

--- a/core/app/models/spree/promotion_rule.rb
+++ b/core/app/models/spree/promotion_rule.rb
@@ -20,6 +20,12 @@ module Spree
       raise 'eligible? should be implemented in a sub-class of Spree::PromotionRule'
     end
 
+    # This states if a promotion can be applied to the specified line item
+    # It is true by default, but can be overridden by promotion rules to provide conditions
+    def actionable?(line_item)
+      true
+    end
+
     private
     def unique_per_promotion
       if Spree::PromotionRule.exists?(promotion_id: promotion_id, type: self.class.name)

--- a/core/spec/models/spree/item_adjustments_spec.rb
+++ b/core/spec/models/spree/item_adjustments_spec.rb
@@ -175,11 +175,10 @@ module Spree
             line_item_promos[promo_sequence[1]].activate order: order
 
             order.reload
-            order.all_adjustments.count.should eq(2), "Expected two adjustments (using sequence #{promo_sequence})"
+            order.all_adjustments.count.should eq(1), "Expected one adjustment (using sequence #{promo_sequence})"
             order.all_adjustments.eligible.count.should eq(1), "Expected one elegible adjustment (using sequence #{promo_sequence})"
-            # TODO: Really, with the rule we've applied to these promos, we'd expect line_item_promo2
-            # to be selected; however, all of the rules are currently completely broken for line-item-
-            # level promos. To make this spec work for now we just roll with current behavior.
+            # line_item_promo1 is the only one that has thus far met the order total threshold, it is the only promo which should be applied.
+            order.all_adjustments.first.source.promotion.should eq(line_item_promo1), "Expected line_item_promo1 to be used (using sequence #{promo_sequence})"
 
             order.contents.add create(:variant, price: 10), 1
             order.save

--- a/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_adjustment_spec.rb
@@ -4,6 +4,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
   let(:order) { create(:order_with_line_items, :line_items_count => 1) }
   let(:promotion) { create(:promotion) }
   let(:action) { Spree::Promotion::Actions::CreateAdjustment.new }
+  let(:payload) { { order: order } }
 
   # From promotion spec:
   context "#perform" do
@@ -16,7 +17,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     # Regression test for #3966
     it "does not apply an adjustment if the amount is 0" do
       action.calculator.preferred_amount = 0
-      action.perform(:order => order)
+      action.perform(payload)
       promotion.credits_count.should == 0
       order.adjustments.count.should == 0
     end
@@ -24,14 +25,14 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     it "should create a discount with correct negative amount" do
       order.shipments.create!(:cost => 10)
 
-      action.perform(:order => order)
+      action.perform(payload)
       promotion.credits_count.should == 1
       order.adjustments.count.should == 1
       order.adjustments.first.amount.to_i.should == -10
     end
 
     it "should create a discount accessible through both order_id and adjustable_id" do
-      action.perform(:order => order)
+      action.perform(payload)
       order.adjustments.count.should == 1
       order.all_adjustments.count.should == 1
     end
@@ -39,8 +40,8 @@ describe Spree::Promotion::Actions::CreateAdjustment do
     it "should not create a discount when order already has one from this promotion" do
       order.shipments.create!(:cost => 10)
 
-      action.perform(:order => order)
-      action.perform(:order => order)
+      action.perform(payload)
+      action.perform(payload)
       promotion.credits_count.should == 1
     end
   end
@@ -53,7 +54,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
 
     context "when order is not complete" do
       it "should not keep the adjustment" do
-        action.perform(:order => order)
+        action.perform(payload)
         action.destroy
         order.adjustments.count.should == 0
       end
@@ -65,7 +66,7 @@ describe Spree::Promotion::Actions::CreateAdjustment do
       end
 
       before(:each) do
-        action.perform(:order => order)
+        action.perform(payload)
         action.destroy
       end
 

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -69,19 +69,29 @@ module Spree
         context "#compute_amount" do
           before { promotion.promotion_actions = [action] }
 
-          it "calls compute on the calculator" do
-            action.calculator.should_receive(:compute).with(line_item)
-            action.compute_amount(line_item)
-          end
-
-          context "calculator returns amount greater than item total" do
-            before do
-              action.calculator.should_receive(:compute).with(line_item).and_return(300)
-              line_item.stub(amount: 100)
+          context "when the adjustable is actionable" do
+            it "calls compute on the calculator" do
+              action.calculator.should_receive(:compute).with(line_item)
+              action.compute_amount(line_item)
             end
 
-            it "does not exceed it" do
-              action.compute_amount(line_item).should eql(-100)
+            context "calculator returns amount greater than item total" do
+              before do
+                action.calculator.should_receive(:compute).with(line_item).and_return(300)
+                line_item.stub(amount: 100)
+              end
+
+              it "does not exceed it" do
+                action.compute_amount(line_item).should eql(-100)
+              end
+            end
+          end
+
+          context "when the adjustable is not actionable" do
+            before { allow(promotion).to receive(:line_item_actionable?) { false } }
+
+            it 'returns 0' do
+              expect(action.compute_amount(line_item)).to eql(0)
             end
           end
         end

--- a/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_item_adjustments_spec.rb
@@ -8,6 +8,7 @@ module Spree
         let(:promotion) { create(:promotion) }
         let(:action) { CreateItemAdjustments.new }
         let!(:line_item) { create(:line_item, :order => order) }
+        let(:payload) { { order: order, promotion: promotion } }
 
         before { action.stub(:promotion => promotion) }
 
@@ -19,7 +20,7 @@ module Spree
             end
 
             it "does not create an adjustment when calculator returns 0" do
-              action.perform(order: order)
+              action.perform(payload)
               action.adjustments.should be_empty
             end
           end
@@ -31,29 +32,32 @@ module Spree
             end
 
             it "creates adjustment with item as adjustable" do
-              action.perform(order: order)
+              action.perform(payload)
               action.adjustments.count.should == 1
               line_item.reload.adjustments.should == action.adjustments
             end
 
             it "creates adjustment with self as source" do
-              action.perform(order: order)
+              action.perform(payload)
               expect(line_item.reload.adjustments.first.source).to eq action
             end
 
             it "does not perform twice on the same item" do
-              2.times { action.perform(order: order) }
+              2.times { action.perform(payload) }
               action.adjustments.count.should == 1
             end
 
             context "with products rules" do
-              before do
-                promotion.stub(:product_ids => [line_item.product.id])
-              end
               let!(:second_line_item) { create(:line_item, :order => order) }
+              let(:rule) { double Spree::Promotion::Rules::Product }
+
+              before do
+                promotion.stub(:eligible_rules) { [rule] }
+                rule.stub(:actionable?).and_return(true, false)
+              end
 
               it "does not create an adjustmenty for line_items not in product rule" do
-                action.perform(order: order)
+                action.perform(payload)
                 expect(action.adjustments.count).to eql 1
                 expect(line_item.reload.adjustments).to match_array action.adjustments
                 expect(second_line_item.reload.adjustments).to be_empty

--- a/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
@@ -6,6 +6,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
   let(:promotion) { stub_model(Spree::Promotion) }
   let(:shirt) { create(:variant) }
   let(:mug) { create(:variant) }
+  let(:payload) { { order: order } }
 
   context "#perform" do
     before do
@@ -26,7 +27,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
       end
 
       it "adds line items to order with correct variant and quantity" do
-        action.perform(:order => order)
+        action.perform(payload)
         order.line_items.count.should == 2
         line_item = order.line_items.find_by_variant_id(mug.id)
         line_item.should_not be_nil
@@ -35,7 +36,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
 
       it "only adds the delta of quantity to an order" do
         order.contents.add(shirt, 1)
-        action.perform(:order => order)
+        action.perform(payload)
         line_item = order.line_items.find_by_variant_id(shirt.id)
         line_item.should_not be_nil
         line_item.quantity.should == 2
@@ -43,7 +44,7 @@ describe Spree::Promotion::Actions::CreateLineItems do
 
       it "doesn't add if the quantity is greater" do
         order.contents.add(shirt, 3)
-        action.perform(:order => order)
+        action.perform(payload)
         line_item = order.line_items.find_by_variant_id(shirt.id)
         line_item.should_not be_nil
         line_item.quantity.should == 3

--- a/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
+++ b/core/spec/models/spree/promotion/actions/free_shipping_spec.rb
@@ -4,6 +4,7 @@ describe Spree::Promotion::Actions::FreeShipping do
   let(:order) { create(:completed_order_with_totals) }
   let(:promotion) { create(:promotion) }
   let(:action) { Spree::Promotion::Actions::FreeShipping.create }
+  let(:payload) { { order: order } }
 
   # From promotion spec:
   context "#perform" do
@@ -16,7 +17,7 @@ describe Spree::Promotion::Actions::FreeShipping do
       order.shipments.count.should == 2
       order.shipments.first.cost.should == 100
       order.shipments.last.cost.should == 100
-      action.perform(:order => order).should be_true
+      action.perform(payload).should be_true
       promotion.credits_count.should == 2
       order.shipment_adjustments.count.should == 2
       order.shipment_adjustments.first.amount.to_i.should == -100
@@ -24,8 +25,8 @@ describe Spree::Promotion::Actions::FreeShipping do
     end
 
     it "should not create a discount when order already has one from this promotion" do
-      action.perform(:order => order).should be_true
-      action.perform(:order => order).should be_false
+      action.perform(payload).should be_true
+      action.perform(payload).should be_false
       promotion.credits_count.should == 2
       order.shipment_adjustments.count.should == 2
     end

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -237,34 +237,6 @@ describe Spree::Promotion do
     end
   end
 
-  context "#products" do
-    let(:promotion) { create(:promotion) }
-
-    context "when it has product rules with products associated" do
-      let(:promotion_rule) { Spree::Promotion::Rules::Product.new }
-
-      before do
-        promotion_rule.promotion = promotion
-        promotion_rule.products << create(:product)
-        promotion_rule.save
-      end
-
-      it "should have products" do
-        promotion.reload.products.size.should == 1
-      end
-    end
-
-    context "when there's no product rule associated" do
-      before(:each) do
-        promotion.stub_chain(:rules, :to_a).and_return([mock_model(Spree::Promotion::Rules::User)])
-      end
-
-      it "should not have products but still return an empty array" do
-        promotion.products.should be_blank
-      end
-    end
-  end
-
   context "#eligible?" do
     before do
       @order = create(:order)
@@ -285,16 +257,16 @@ describe Spree::Promotion do
     end
   end
 
-  context "#rules_are_eligible?" do
+  context "#eligible_rules" do
     let(:promotable) { double('Promotable') }
     it "true if there are no rules" do
-      promotion.rules_are_eligible?(promotable).should be_true
+      promotion.eligible_rules(promotable).should eq []
     end
 
     it "true if there are no applicable rules" do
       promotion.promotion_rules = [stub_model(Spree::PromotionRule, :eligible? => true, :applicable? => false)]
       promotion.promotion_rules.stub(:for).and_return([])
-      promotion.rules_are_eligible?(promotable).should be_true
+      promotion.eligible_rules(promotable).should eq []
     end
 
     context "with 'all' match policy" do
@@ -308,7 +280,7 @@ describe Spree::Promotion do
 
         promotion.promotion_rules = [promo1, promo2]
         promotion.promotion_rules.stub(:for).and_return(promotion.promotion_rules)
-        promotion.rules_are_eligible?(promotable).should be_true
+        promotion.eligible_rules(promotable).should eq [promo1, promo2]
       end
 
       it "should not have eligible rules if any of the rules is not eligible" do
@@ -319,7 +291,7 @@ describe Spree::Promotion do
 
         promotion.promotion_rules = [promo1, promo2]
         promotion.promotion_rules.stub(:for).and_return(promotion.promotion_rules)
-        promotion.rules_are_eligible?(promotable).should be_false
+        promotion.eligible_rules(promotable).should be_nil
       end
     end
 
@@ -333,9 +305,65 @@ describe Spree::Promotion do
         true_rule.stub(:eligible? => true)
         promotion.stub(:rules => [true_rule])
         promotion.stub_chain(:rules, :for).and_return([true_rule])
-        promotion.rules_are_eligible?(promotable).should be_true
+        promotion.eligible_rules(promotable).should eq [true_rule]
       end
     end
+  end
+
+  describe '#line_item_actionable?' do
+    let(:order) { double Spree::Order }
+    let(:line_item) { double Spree::LineItem}
+    let(:true_rule) { double Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: true }
+    let(:false_rule) { double Spree::PromotionRule, eligible?: true, applicable?: true, actionable?: false }
+    let(:rules) { [] }
+
+    before do
+      promotion.stub(:rules) { rules }
+      rules.stub(:for) { rules }
+    end
+
+    subject { promotion.line_item_actionable? order, line_item }
+
+    context 'when the order is eligible for promotion' do
+      context 'when there are no rules' do
+        it { should be }
+      end
+
+      context 'when there are rules' do
+        context 'when the match policy is all' do
+          before { promotion.match_policy = 'all' }
+
+          context 'when all rules allow action on the line item' do
+            let(:rules) { [true_rule] }
+            it { should be}
+          end
+
+          context 'when at least one rule does not allow action on the line item' do
+            let(:rules) { [true_rule, false_rule] }
+            it { should_not be}
+          end
+        end
+
+        context 'when the match policy is any' do
+          before { promotion.match_policy = 'any' }
+
+          context 'when at least one rule allows action on the line item' do
+            let(:rules) { [true_rule, false_rule] }
+            it { should be }
+          end
+
+          context 'when no rules allow action on the line item' do
+            let(:rules) { [false_rule] }
+            it { should_not be}
+          end
+        end
+      end
+    end
+
+      context 'when the order is not eligible for the promotion' do
+        before { promotion.starts_at = Time.current + 2.days }
+        it { should_not be }
+      end
   end
 
   # regression for #4059

--- a/frontend/app/views/spree/checkout/_summary.html.erb
+++ b/frontend/app/views/spree/checkout/_summary.html.erb
@@ -7,9 +7,9 @@
       <td><strong><%= order.display_item_total.to_html %></strong></td>
     </tr>
 
-    <% if order.line_item_adjustments.exists? %>
+    <% if order.line_item_adjustments.nonzero.exists? %>
       <tbody data-hook="order_details_promotion_adjustments">
-        <% order.line_item_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+        <% order.line_item_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
           <tr class="total">
             <td><%= label %></td>
             <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
@@ -19,7 +19,7 @@
     <% end %>
 
     <tbody data-hook="order_details_tax_adjustments">
-      <% order.all_adjustments.tax.eligible.group_by(&:label).each do |label, adjustments| %>
+      <% order.all_adjustments.nonzero.tax.eligible.group_by(&:label).each do |label, adjustments| %>
         <tr class="total">
           <td><%= label %></td>
           <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
@@ -33,9 +33,9 @@
         <td><%= Spree::Money.new(order.shipments.to_a.sum(&:cost), currency: order.currency).to_html %></td>
       </tr>
 
-      <% if order.shipment_adjustments.exists? %>
+      <% if order.shipment_adjustments.nonzero.exists? %>
         <tbody data-hook="order_details_shipment_promotion_adjustments">
-          <% order.shipment_adjustments.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
+          <% order.shipment_adjustments.nonzero.promotion.eligible.group_by(&:label).each do |label, adjustments| %>
             <tr class="total">
               <td><%= label %></td>
               <td><%= Spree::Money.new(adjustments.sum(&:amount), currency: order.currency).to_html %></td>
@@ -45,9 +45,9 @@
       <% end %>
     <% end %>
 
-    <% if order.adjustments.eligible.exists? %>
+    <% if order.adjustments.nonzero.eligible.exists? %>
       <tbody id="summary-order-charges" data-hook>
-        <% order.adjustments.eligible.each do |adjustment| %>
+        <% order.adjustments.nonzero.eligible.each do |adjustment| %>
         <% next if (adjustment.source_type == 'Spree::TaxRate') and (adjustment.amount == 0) %>
           <tr class="total">
             <td><%= adjustment.label %>: </td>

--- a/frontend/app/views/spree/orders/_adjustment_row.html.erb
+++ b/frontend/app/views/spree/orders/_adjustment_row.html.erb
@@ -1,6 +1,8 @@
-<tr class="adjustment">
-  <td colspan="4" align='right'><h5><%= type %>: <%= label %></h5></td>
-  <td colspan='2'>
-    <h5><%= Spree::Money.new(adjustments.sum(&:amount), :currency => @order.currency) %></h5>
-  </td>
-</tr>
+<% if adjustments.sum(&:amount) != 0 %>
+  <tr class="adjustment">
+    <td colspan="4" align='right'><h5><%= type %>: <%= label %></h5></td>
+    <td colspan='2'>
+      <h5><%= Spree::Money.new(adjustments.sum(&:amount), :currency => @order.currency) %></h5>
+    </td>
+  </tr>
+<% end %>

--- a/frontend/app/views/spree/orders/_form.html.erb
+++ b/frontend/app/views/spree/orders/_form.html.erb
@@ -12,7 +12,7 @@
   <tbody id="line_items" data-hook>
     <%= render partial: 'line_item', collection: order_form.object.line_items, locals: {order_form: order_form} %>
   </tbody>
-  <% if @order.adjustments.exists? || @order.line_item_adjustments.exists? || @order.shipment_adjustments.exists? %>
+  <% if @order.adjustments.nonzero.exists? || @order.line_item_adjustments.nonzero.exists? || @order.shipment_adjustments.nonzero.exists? || @order.shipments.any? %>
     <tr class="cart-subtotal">
       <td colspan="4" align='right'><h5><%= Spree.t(:cart_subtotal, :count => @order.line_items.sum(:quantity)) %></h5></th>
       <td colspan><h5><%= order_form.object.display_item_total %></h5></td>


### PR DESCRIPTION
This brings in a major refactor to promotion actions and eligibility which will make line item promotions work in a manner more consistent with how we would like them to be used.

Specifically, if a line item qualifies for a promotion, the promotion rule will only be applied to that line item, and if the line item no longer qualifies due to a change in quantity, the adjustment will be changed to 0.
