### PR TITLE
Adds 'current order' API endpoint

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -60,6 +60,7 @@ Spree::Core::Engine.add_routes do
     end
 
     get '/orders/mine', to: 'orders#mine', as: 'my_orders'
+    get "/orders/current", to: "orders#current", to: "orders#current", as: "current_order"
 
     resources :orders, concerns: :order_routes
 

--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -86,6 +86,49 @@ module Spree
       end
     end
 
+    describe 'current' do
+      let(:current_api_user) { order.user }
+      let!(:order) { create(:order, line_items: [line_item]) }
+
+      subject do
+        api_get :current, format: 'json'
+      end
+
+      context "an incomplete order exists" do
+        it "returns that order" do
+          expect(JSON.parse(subject.body)['id']).to eq order.id
+          expect(subject).to be_success
+        end
+      end
+
+      context "multiple incomplete orders exist" do
+        it "returns the latest incomplete order" do
+          new_order = Spree::Order.create! user: order.user
+          expect(new_order.created_at).to be > order.created_at
+          expect(JSON.parse(subject.body)['id']).to eq new_order.id
+        end
+      end
+
+      context "an incomplete order does not exist" do
+
+        before do
+          order.update_attribute(:state, order_state)
+          order.update_attribute(:completed_at, 5.minutes.ago)
+        end
+
+        ["complete", "returned", "awaiting_return"].each do |order_state|
+          context "order is in the #{order_state} state" do
+            let(:order_state) { order_state }
+
+            it "returns no content" do
+              expect(subject.status).to eq 204
+              expect(subject.body).to be_blank
+            end
+          end
+        end
+      end
+    end
+
     it "can view their own order" do
       Order.any_instance.stub :user => current_api_user
       api_get :show, :id => order.to_param


### PR DESCRIPTION
This enables an API client to load a user's latest order. At Bonobos, we
use this to load the user's last active cart.

The find_current_order method is broken out to a separate method to
enable gems like spree-multi-store to customize its behavior.

Closes #5069
