### PR TITLE
Indexing the guest_token column on spree_orders

### DIFF
--- a/core/db/migrate/20141120135441_add_guest_token_index_to_spree_orders.rb
+++ b/core/db/migrate/20141120135441_add_guest_token_index_to_spree_orders.rb
@@ -1,0 +1,5 @@
+class AddGuestTokenIndexToSpreeOrders < ActiveRecord::Migration
+  def change
+    add_index :spree_orders, :guest_token
+  end
+end


### PR DESCRIPTION
Cherry-pick back from spree master. This is currently an inefficient query when there are large numbers of incomplete orders, when it should be a simple lookup.
