### PR TITLE
fix handling of credit cards expiring in current month

### DIFF
--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -129,8 +129,8 @@ module Spree
         if month.to_i < 1 || month.to_i > 12
           errors.add(:base, :expiry_invalid)
         else
-          time = Time.zone.parse("#{year}-#{month}-1")
-          if time < Time.zone.now.to_time.beginning_of_month
+          current = Time.current
+          if year.to_i < current.year or (year.to_i == current.year and month.to_i < current.month)
             errors.add(:base, :card_expired)
           end
         end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -108,6 +108,13 @@ describe Spree::CreditCard do
       credit_card.errors[:base].should == ["Card has expired"]
     end
 
+    it "should not be expired expiring on the current month" do
+      credit_card.attributes = valid_credit_card_attributes
+      credit_card.month = Time.zone.now.month
+      credit_card.year = Time.zone.now.year
+      credit_card.should be_valid
+    end
+
     it "should handle TZ correctly" do
       # The card is valid according to the system clock's local time
       # (Time.now).


### PR DESCRIPTION
This counts credit cards expiring in the current month as being not expired.
