### PR TITLE
Fix for failure of one of multiple payments.

### DIFF
--- a/frontend/app/controllers/spree/checkout_controller.rb
+++ b/frontend/app/controllers/spree/checkout_controller.rb
@@ -46,22 +46,35 @@ module Spree
     end
 
     private
-      def ensure_valid_state
-        unless skip_state_validation?
-          if (params[:state] && !@order.has_checkout_step?(params[:state])) ||
-             (!params[:state] && !@order.has_checkout_step?(@order.state))
-            @order.state = 'cart'
-            redirect_to checkout_state_path(@order.checkout_steps.first)
-          end
-        end
 
-        # Fix for #4117
-        # If confirmation of payment fails, redirect back to payment screen
-        if params[:state] == "confirm" && @order.payment_required? && @order.payments.valid.empty?
-          flash.keep
-          redirect_to checkout_state_path("payment")
-        end
+    def unknown_state?
+      (params[:state] && !@order.has_checkout_step?(params[:state])) ||
+        (!params[:state] && !@order.has_checkout_step?(@order.state))
+    end
+
+    def insufficient_payment?
+      params[:state] == "confirm" &&
+        @order.payment_required? &&
+        @order.payments.valid.sum(:amount) != @order.amount
+    end
+
+    def correct_state
+      if unknown_state?
+        @order.checkout_steps.first
+      elsif insufficient_payment?
+        'payment'
+      else
+        @order.state
       end
+    end
+
+    def ensure_valid_state
+      if @order.state != correct_state && !skip_state_validation?
+        flash.keep
+        @order.state = correct_state
+        redirect_to checkout_state_path(@order.state)
+      end
+    end
 
       # Should be overriden if you have areas of your checkout that don't match
       # up to a step within checkout_steps, such as a registration step

--- a/frontend/spec/features/checkout_spec.rb
+++ b/frontend/spec/features/checkout_spec.rb
@@ -164,7 +164,7 @@ describe "Checkout", inaccessible: true do
     end
 
     it "prevents double clicking the confirm button on checkout", :js => true do
-      order.payments << create(:payment)
+      order.payments << create(:payment, amount: order.amount)
       visit spree.checkout_state_path(:confirm)
 
       # prevent form submit to verify button is disabled


### PR DESCRIPTION
This corrects an issue which would leave the user on the confirm page
when one of multiple payments failed. This would allow the user to
proceed through the confirm step with an invalid payment, not billing
them for the full amount required.
