### PR TITLE
Address factory uses valid phone number.

### DIFF
--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -7,8 +7,8 @@ FactoryGirl.define do
     address2 'Northwest'
     city 'Herndon'
     zipcode '35005'
-    phone '123-456-7890'
-    alternative_phone '123-456-7899'
+    phone '555-555-0199'
+    alternative_phone '555-555-0199'
 
     state { |address| address.association(:state) }
     country do |address|


### PR DESCRIPTION
Area codes can not begin with 1, therefore the area code for this phone
number is invalid.

This causes issues for anyone who wishes to implement some level of
basic phone number validation, as if they use the address factory it
will cause their validations to fail.
