### PR TITLE
Backend: when refreshing shipping rates, include backend only shipping m...

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -25,7 +25,7 @@ module Spree
             end
             while @order.next; end
 
-            @order.refresh_shipment_rates
+            @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to admin_order_customer_path(@order)
           else

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -54,7 +54,7 @@ module Spree
 
       def edit
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
         end
       end
 

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -99,6 +99,23 @@ describe "Order Details", js: true do
         page.should have_content("Default")
       end
 
+      it "can assign a back-end only shipping method" do
+        create(:shipping_method, name: "Backdoor", display_on: "back_end")
+        order = create(
+          :completed_order_with_totals,
+          shipping_method_filter: Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END
+        )
+        visit spree.edit_admin_order_path(order)
+        within("table.index tr.show-method") do
+          click_icon :edit
+        end
+        select2 "Backdoor", from: "Shipping Method"
+        click_icon :ok
+
+        expect(page).not_to have_css('#selected_shipping_rate_id')
+        expect(page).to have_content("Backdoor")
+      end
+
       it "will show the variant sku" do
         order = create(:completed_order_with_totals)
         visit spree.edit_admin_order_path(order)
@@ -200,9 +217,10 @@ describe "Order Details", js: true do
           end
         end
       end
-      
+
       context "with special_instructions present" do
         let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100", :special_instructions => "Very special instructions here") }
+
         it "will show the special_instructions" do
           visit spree.edit_admin_order_path(order)
           expect(page).to have_content("Very special instructions here")

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -516,8 +516,8 @@ module Spree
       )
     end
 
-    def refresh_shipment_rates
-      shipments.map &:refresh_rates
+    def refresh_shipment_rates(shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
+      shipments.map { |s| s.refresh_rates(shipping_method_filter) }
     end
 
     def shipping_eq_billing_address?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -206,6 +206,26 @@ module Spree
       manifest.each { |item| manifest_unstock(item) }
     end
 
+    def refresh_rates(shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
+      return shipping_rates if shipped?
+      return [] unless can_get_rates?
+
+      # StockEstimator.new assigment below will replace the current shipping_method
+      original_shipping_method_id = shipping_method.try(:id)
+
+      self.shipping_rates = Stock::Estimator.new(order).
+      shipping_rates(to_package, shipping_method_filter)
+
+      if shipping_method
+        selected_rate = shipping_rates.detect { |rate|
+          rate.shipping_method_id == original_shipping_method_id
+        }
+        self.selected_shipping_rate_id = selected_rate.id if selected_rate
+      end
+
+      shipping_rates
+    end
+
     def after_cancel
       manifest.each { |item| manifest_restock(item) }
     end

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -5,6 +5,11 @@ module Spree
     DISPLAY = [:both, :front_end, :back_end]
 
     default_scope -> { where(deleted_at: nil) }
+    #
+    # Used for #refresh_rates
+    DISPLAY_ON_FRONT_AND_BACK_END = 0
+    DISPLAY_ON_FRONT_END = 1
+    DISPLAY_ON_BACK_END = 2
 
     has_many :shipping_method_categories, :dependent => :destroy
     has_many :shipping_categories, through: :shipping_method_categories
@@ -44,6 +49,12 @@ module Spree
 
     def tax_category
       Spree::TaxCategory.unscoped { super }
+    end
+
+    def available_to_display(display_filter)
+      display_filter == DISPLAY_ON_FRONT_AND_BACK_END ||
+      (frontend? && display_filter == DISPLAY_ON_FRONT_END) ||
+      (!frontend? && display_filter == DISPLAY_ON_BACK_END)
     end
 
     private

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -18,6 +18,8 @@ FactoryGirl.define do
 
       ignore do
         line_items_count 1
+        shipment_cost 100
+        shipping_method_filter Spree::ShippingMethod::DISPLAY_ON_FRONT_END
       end
 
       after(:create) do |order, evaluator|
@@ -33,8 +35,8 @@ FactoryGirl.define do
       factory :completed_order_with_totals do
         state 'complete'
 
-        after(:create) do |order|
-          order.refresh_shipment_rates
+        after(:create) do |order, evaluator|
+          order.refresh_shipment_rates(evaluator.shipping_method_filter)
           order.update_column(:completed_at, Time.now)
         end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -117,7 +117,7 @@ module Spree
           before do
             backend_method.stub_chain(:calculator, :compute).and_return(0.00)
             generic_method.stub_chain(:calculator, :compute).and_return(5.00)
-            subject.stub(:shipping_methods).and_return([backend_method, generic_method])
+            allow(package).to receive(:shipping_methods).and_return([backend_method, generic_method])
           end
 
           it "does not return backend rates at all" do


### PR DESCRIPTION
...ethods

Add specs for the back_end only shipping methods changes

This is a backport from spree master 1c1caf30cf36bf80e008ebb6c5b1b5d2e9e676bb

Conflicts:
    backend/app/controllers/spree/admin/orders/customer_details_controller.rb
    backend/spec/features/admin/orders/order_details_spec.rb
    core/app/models/spree/shipment.rb
    core/app/models/spree/shipping_method.rb
    core/lib/spree/testing_support/factories/order_factory.rb
    core/spec/models/spree/stock/estimator_spec.rb
